### PR TITLE
Add more granular permissions

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -315,9 +315,9 @@ class listener implements EventSubscriberInterface
 		], $event['post_data']);
 
 		$this->markdown_enabled = $this->markdown_enabled &&
+			!empty($this->config['allow_post_markdown']) &&
 			!empty($this->auth->acl_get('f_markdown', $event['forum_id'])) &&
 			!empty($this->auth->acl_get('u_post_markdown')) &&
-			!empty($this->config['allow_post_markdown']) &&
 			!empty($event['post_data']['enable_markdown']);
 
 		$this->template->assign_var(
@@ -360,8 +360,8 @@ class listener implements EventSubscriberInterface
 		$event['enable_markdown'] = empty($this->request->variable('disable_markdown', false));
 
 		$this->markdown_enabled = $this->markdown_enabled &&
-			!empty($this->auth->acl_get('u_pm_markdown')) &&
 			!empty($this->config['allow_pm_markdown']) &&
+			!empty($this->auth->acl_get('u_pm_markdown')) &&
 			!empty($event['enable_markdown']);
 
 		$this->template->assign_var(
@@ -390,8 +390,8 @@ class listener implements EventSubscriberInterface
 		$event['allow_markdown'] = empty($this->request->variable('disable_markdown', false));
 
 		$this->markdown_enabled = $this->markdown_enabled &&
-			!empty($this->auth->acl_get('u_sig_markdown')) &&
 			!empty($this->config['allow_sig_markdown']) &&
+			!empty($this->auth->acl_get('u_sig_markdown')) &&
 			!empty($event['allow_markdown']);
 
 		$this->template->assign_var(

--- a/event/listener.php
+++ b/event/listener.php
@@ -73,7 +73,6 @@ class listener implements EventSubscriberInterface
 		$this->language = $language;
 		$this->helper = $helper;
 		$this->markdown_enabled = !empty($this->config['allow_markdown']) &&
-			!empty($this->auth->acl_get('u_markdown')) &&
 			!empty($this->user->data['user_allow_markdown']);
 	}
 
@@ -126,7 +125,15 @@ class listener implements EventSubscriberInterface
 	 */
 	public function acp_markdown_configuration($event)
 	{
-		if (!in_array($event['mode'], ['features', 'signature'], true))
+		// Allowed modes
+		$modes = [
+			'features',
+			'post',
+			'message',
+			'signature'
+		];
+
+		if (!in_array($event['mode'], $modes, true))
 		{
 			return;
 		}
@@ -157,9 +164,9 @@ class listener implements EventSubscriberInterface
 
 		$event->update_subarray(
 			'permissions',
-			'u_markdown',
+			'u_post_markdown',
 			[
-				'lang' => 'ACL_U_MARKDOWN',
+				'lang' => 'ACL_U_POST_MARKDOWN',
 				'cat' => 'post'
 			]
 		);
@@ -170,6 +177,15 @@ class listener implements EventSubscriberInterface
 			[
 				'lang' => 'ACL_U_PM_MARKDOWN',
 				'cat' => 'pm'
+			]
+		);
+
+		$event->update_subarray(
+			'permissions',
+			'u_sig_markdown',
+			[
+				'lang' => 'ACL_U_SIG_MARKDOWN',
+				'cat' => 'profile'
 			]
 		);
 	}
@@ -300,6 +316,8 @@ class listener implements EventSubscriberInterface
 
 		$this->markdown_enabled = $this->markdown_enabled &&
 			!empty($this->auth->acl_get('f_markdown', $event['forum_id'])) &&
+			!empty($this->auth->acl_get('u_post_markdown')) &&
+			!empty($this->config['allow_post_markdown']) &&
 			!empty($event['post_data']['enable_markdown']);
 
 		$this->template->assign_var(
@@ -343,6 +361,7 @@ class listener implements EventSubscriberInterface
 
 		$this->markdown_enabled = $this->markdown_enabled &&
 			!empty($this->auth->acl_get('u_pm_markdown')) &&
+			!empty($this->config['allow_pm_markdown']) &&
 			!empty($event['enable_markdown']);
 
 		$this->template->assign_var(
@@ -371,6 +390,7 @@ class listener implements EventSubscriberInterface
 		$event['allow_markdown'] = empty($this->request->variable('disable_markdown', false));
 
 		$this->markdown_enabled = $this->markdown_enabled &&
+			!empty($this->auth->acl_get('u_sig_markdown')) &&
 			!empty($this->config['allow_sig_markdown']) &&
 			!empty($event['allow_markdown']);
 

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -26,6 +26,13 @@ class helper
 			return [];
 		}
 
+		// Common field options
+		$options = [
+			'validate' => 'bool',
+			'type' => 'radio:yes_no',
+			'explain' => false
+		];
+
 		switch ($mode)
 		{
 			case 'features':
@@ -33,12 +40,36 @@ class helper
 					$display_vars['vars'],
 					'allow_pm_report',
 					[
-						'allow_markdown' => [
-							'lang' => 'ALLOW_MARKDOWN',
-							'validate' => 'bool',
-							'type' => 'radio:yes_no',
-							'explain' => false
-						]
+						'allow_markdown' => array_merge(
+							['lang' => 'ALLOW_MARKDOWN'],
+							$options
+						)
+					]
+				);
+			break;
+
+			case 'post':
+				$display_vars['vars'] = $this->array_insert_after(
+					$display_vars['vars'],
+					'allow_forum_notify',
+					[
+						'allow_post_markdown' => array_merge(
+							['lang' => 'ALLOW_POST_MARKDOWN'],
+							$options
+						)
+					]
+				);
+			break;
+
+			case 'message':
+				$display_vars['vars'] = $this->array_insert_after(
+					$display_vars['vars'],
+					'allow_mass_pm',
+					[
+						'allow_pm_markdown' => array_merge(
+							['lang' => 'ALLOW_PM_MARKDOWN'],
+							$options
+						)
 					]
 				);
 			break;
@@ -48,12 +79,10 @@ class helper
 					$display_vars['vars'],
 					'allow_sig',
 					[
-						'allow_sig_markdown' => [
-							'lang' => 'ALLOW_SIG_MARKDOWN',
-							'validate' => 'bool',
-							'type' => 'radio:yes_no',
-							'explain' => false
-						]
+						'allow_sig_markdown' => array_merge(
+							['lang' => 'ALLOW_SIG_MARKDOWN'],
+							$options
+						)
 					]
 				);
 			break;

--- a/language/en/acp/info_acp_markdown.php
+++ b/language/en/acp/info_acp_markdown.php
@@ -25,5 +25,7 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'ALLOW_MARKDOWN' => 'Allow Markdown',
+	'ALLOW_POST_MARKDOWN' => 'Allow Markdown in posts',
+	'ALLOW_PM_MARKDOWN' => 'Allow Markdown in private messages',
 	'ALLOW_SIG_MARKDOWN' => 'Allow Markdown in user signatures'
 ]);

--- a/language/en/acp/permissions_markdown.php
+++ b/language/en/acp/permissions_markdown.php
@@ -25,6 +25,7 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'ACL_F_MARKDOWN' => 'Can use Markdown',
-	'ACL_U_MARKDOWN' => 'Can use Markdown',
-	'ACL_U_PM_MARKDOWN' => 'Can use Markdown in private messages'
+	'ACL_U_POST_MARKDOWN' => 'Can use Markdown',
+	'ACL_U_PM_MARKDOWN' => 'Can use Markdown in private messages',
+	'ACL_U_SIG_MARKDOWN' => 'Can use Markdown in signature'
 ]);

--- a/language/es/acp/info_acp_markdown.php
+++ b/language/es/acp/info_acp_markdown.php
@@ -25,5 +25,7 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'ALLOW_MARKDOWN' => 'Permitir Markdown',
+	'ALLOW_POST_MARKDOWN' => 'Permitir Markdown en mensajes',
+	'ALLOW_PM_MARKDOWN' => 'Permitir Markdown en mensajes privados',
 	'ALLOW_SIG_MARKDOWN' => 'Permitir Markdown en la firma del usuario'
 ]);

--- a/language/es/acp/permissions_markdown.php
+++ b/language/es/acp/permissions_markdown.php
@@ -25,6 +25,7 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'ACL_F_MARKDOWN' => 'Puede usar Markdown',
-	'ACL_U_MARKDOWN' => 'Puede usar Markdown',
-	'ACL_U_PM_MARKDOWN' => 'Puede usar Markdown en mensajes privados'
+	'ACL_U_POST_MARKDOWN' => 'Puede usar Markdown',
+	'ACL_U_PM_MARKDOWN' => 'Puede usar Markdown en mensajes privados',
+	'ACL_U_SIG_MARKDOWN' => 'Puede usar Markdown en la firma del usuario'
 ]);

--- a/language/es_x_tu/acp/info_acp_markdown.php
+++ b/language/es_x_tu/acp/info_acp_markdown.php
@@ -25,5 +25,7 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'ALLOW_MARKDOWN' => 'Permitir Markdown',
+	'ALLOW_POST_MARKDOWN' => 'Permitir Markdown en mensajes',
+	'ALLOW_PM_MARKDOWN' => 'Permitir Markdown en mensajes privados',
 	'ALLOW_SIG_MARKDOWN' => 'Permitir Markdown en la firma del usuario'
 ]);

--- a/language/es_x_tu/acp/permissions_markdown.php
+++ b/language/es_x_tu/acp/permissions_markdown.php
@@ -25,6 +25,7 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'ACL_F_MARKDOWN' => 'Puede usar Markdown',
-	'ACL_U_MARKDOWN' => 'Puede usar Markdown',
-	'ACL_U_PM_MARKDOWN' => 'Puede usar Markdown en mensajes privados'
+	'ACL_U_POST_MARKDOWN' => 'Puede usar Markdown',
+	'ACL_U_PM_MARKDOWN' => 'Puede usar Markdown en mensajes privados',
+	'ACL_U_SIG_MARKDOWN' => 'Puede usar Markdown en la firma del usuario'
 ]);

--- a/migrations/v10x/m00_board_configuration.php
+++ b/migrations/v10x/m00_board_configuration.php
@@ -27,6 +27,14 @@ class m00_board_configuration extends migration
 			],
 			[
 				'config.add',
+				['allow_post_markdown', 1]
+			],
+			[
+				'config.add',
+				['allow_pm_markdown', 1]
+			],
+			[
+				'config.add',
 				['allow_sig_markdown', 1]
 			]
 		];

--- a/migrations/v10x/m01_permissions.php
+++ b/migrations/v10x/m01_permissions.php
@@ -27,15 +27,15 @@ class m01_permissions extends migration
 			['permission.permission_set', ['ROLE_FORUM_POLLS', 'f_markdown']],
 			['permission.permission_set', ['ROLE_FORUM_FULL', 'f_markdown']],
 
-			['permission.add', ['u_markdown']],
-			['permission.permission_set', ['ROLE_USER_STANDARD', 'u_markdown']],
-			['permission.permission_set', ['ROLE_USER_FULL', 'u_markdown']],
-			['permission.permission_set', ['ROLE_MOD_STANDARD', 'u_markdown']],
-			['permission.permission_set', ['ROLE_MOD_FULL', 'u_markdown']],
-			['permission.permission_set', ['ROLE_ADMIN_STANDARD', 'u_markdown']],
-			['permission.permission_set', ['ROLE_ADMIN_FULL', 'u_markdown']],
-			['permission.permission_set', ['REGISTERED_COPPA', 'u_markdown', 'group']],
-			['permission.permission_set', ['REGISTERED', 'u_markdown', 'group']],
+			['permission.add', ['u_post_markdown']],
+			['permission.permission_set', ['ROLE_USER_STANDARD', 'u_post_markdown']],
+			['permission.permission_set', ['ROLE_USER_FULL', 'u_post_markdown']],
+			['permission.permission_set', ['ROLE_MOD_STANDARD', 'u_post_markdown']],
+			['permission.permission_set', ['ROLE_MOD_FULL', 'u_post_markdown']],
+			['permission.permission_set', ['ROLE_ADMIN_STANDARD', 'u_post_markdown']],
+			['permission.permission_set', ['ROLE_ADMIN_FULL', 'u_post_markdown']],
+			['permission.permission_set', ['REGISTERED_COPPA', 'u_post_markdown', 'group']],
+			['permission.permission_set', ['REGISTERED', 'u_post_markdown', 'group']],
 
 			['permission.add', ['u_pm_markdown']],
 			['permission.permission_set', ['ROLE_USER_STANDARD', 'u_pm_markdown']],
@@ -45,7 +45,17 @@ class m01_permissions extends migration
 			['permission.permission_set', ['ROLE_ADMIN_STANDARD', 'u_pm_markdown']],
 			['permission.permission_set', ['ROLE_ADMIN_FULL', 'u_pm_markdown']],
 			['permission.permission_set', ['REGISTERED_COPPA', 'u_pm_markdown', 'group']],
-			['permission.permission_set', ['REGISTERED', 'u_pm_markdown', 'group']]
+			['permission.permission_set', ['REGISTERED', 'u_pm_markdown', 'group']],
+
+			['permission.add', ['u_sig_markdown']],
+			['permission.permission_set', ['ROLE_USER_STANDARD', 'u_sig_markdown']],
+			['permission.permission_set', ['ROLE_USER_FULL', 'u_sig_markdown']],
+			['permission.permission_set', ['ROLE_MOD_STANDARD', 'u_sig_markdown']],
+			['permission.permission_set', ['ROLE_MOD_FULL', 'u_sig_markdown']],
+			['permission.permission_set', ['ROLE_ADMIN_STANDARD', 'u_sig_markdown']],
+			['permission.permission_set', ['ROLE_ADMIN_FULL', 'u_sig_markdown']],
+			['permission.permission_set', ['REGISTERED_COPPA', 'u_sig_markdown', 'group']],
+			['permission.permission_set', ['REGISTERED', 'u_sig_markdown', 'group']]
 		];
 	}
 }

--- a/tests/functional/abstract_functional_test_case.php
+++ b/tests/functional/abstract_functional_test_case.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Markdown extension for phpBB.
+ * @author Alfredo Ramos <alfredo.ramos@yandex.com>
+ * @copyright 2019 Alfredo Ramos
+ * @license GPL-2.0-only
+ */
+
+namespace alfredoramos\markdown\tests\functional;
+
+use phpbb_functional_test_case;
+
+class abstract_functional_test_case extends phpbb_functional_test_case
+{
+	static protected function setup_extensions()
+	{
+		return ['alfredoramos/markdown'];
+	}
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->login();
+	}
+}

--- a/tests/functional/acp_markdown_test.php
+++ b/tests/functional/acp_markdown_test.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Markdown extension for phpBB.
+ * @author Alfredo Ramos <alfredo.ramos@yandex.com>
+ * @copyright 2019 Alfredo Ramos
+ * @license GPL-2.0-only
+ */
+
+namespace alfredoramos\markdown\tests\functional;
+
+/**
+ * @group functional
+ */
+class acp_markdown_test extends abstract_functional_test_case
+{
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->add_lang_ext('alfredoramos/markdown', 'acp/info_acp_markdown');
+
+		$this->admin_login();
+	}
+
+	public function test_acp_board_features()
+	{
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=features&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertContains(
+			$this->lang('ALLOW_MARKDOWN'),
+			$crawler->filter('label[for="allow_markdown"]')->text()
+		);
+		$this->assertSame(1, $crawler->filter('#allow_markdown')->count());
+		$this->assertTrue($form->has('config[allow_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_markdown]')->getValue());
+	}
+
+	public function test_acp_post_settings()
+	{
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=post&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertContains(
+			$this->lang('ALLOW_POST_MARKDOWN'),
+			$crawler->filter('label[for="allow_post_markdown"]')->text()
+		);
+		$this->assertSame(1, $crawler->filter('#allow_post_markdown')->count());
+		$this->assertTrue($form->has('config[allow_post_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_post_markdown]')->getValue());
+	}
+
+	public function test_acp_private_message_settings()
+	{
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=message&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertContains(
+			$this->lang('ALLOW_PM_MARKDOWN'),
+			$crawler->filter('label[for="allow_pm_markdown"]')->text()
+		);
+		$this->assertSame(1, $crawler->filter('#allow_pm_markdown')->count());
+		$this->assertTrue($form->has('config[allow_pm_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_pm_markdown]')->getValue());
+	}
+
+	public function test_acp_signature_settings()
+	{
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=signature&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertContains(
+			$this->lang('ALLOW_SIG_MARKDOWN'),
+			$crawler->filter('label[for="allow_sig_markdown"]')->text()
+		);
+		$this->assertSame(1, $crawler->filter('#allow_sig_markdown')->count());
+		$this->assertTrue($form->has('config[allow_sig_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_sig_markdown]')->getValue());
+	}
+}

--- a/tests/functional/markdown_test.php
+++ b/tests/functional/markdown_test.php
@@ -9,160 +9,19 @@
 
 namespace alfredoramos\markdown\tests\functional;
 
-use phpbb_functional_test_case;
-
 /**
  * @group functional
  */
-class markdown_test extends phpbb_functional_test_case
+class markdown_test extends abstract_functional_test_case
 {
-	static protected function setup_extensions()
-	{
-		return ['alfredoramos/markdown'];
-	}
-
 	public function setUp()
 	{
 		parent::setUp();
 
 		$this->add_lang_ext('alfredoramos/markdown', [
-			'acp/info_acp_markdown',
+			'posting',
 			'help/markdown'
 		]);
-
-		$this->login();
-	}
-
-	public function test_acp_board_features()
-	{
-		$this->admin_login();
-
-		$crawler = self::request('GET', sprintf(
-			'adm/index.php?i=acp_board&mode=features&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertContains(
-			$this->lang('ALLOW_MARKDOWN'),
-			$crawler->filter('label[for="allow_markdown"]')->text()
-		);
-		$this->assertSame(1, $crawler->filter('#allow_markdown')->count());
-		$this->assertTrue($form->has('config[allow_markdown]'));
-		$this->assertSame('1', $form->get('config[allow_markdown]')->getValue());
-	}
-
-	public function test_acp_post_settings()
-	{
-		$this->admin_login();
-
-		$crawler = self::request('GET', sprintf(
-			'adm/index.php?i=acp_board&mode=post&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertContains(
-			$this->lang('ALLOW_POST_MARKDOWN'),
-			$crawler->filter('label[for="allow_post_markdown"]')->text()
-		);
-		$this->assertSame(1, $crawler->filter('#allow_post_markdown')->count());
-		$this->assertTrue($form->has('config[allow_post_markdown]'));
-		$this->assertSame('1', $form->get('config[allow_post_markdown]')->getValue());
-	}
-
-	public function test_acp_private_message_settings()
-	{
-		$this->admin_login();
-
-		$crawler = self::request('GET', sprintf(
-			'adm/index.php?i=acp_board&mode=message&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertContains(
-			$this->lang('ALLOW_PM_MARKDOWN'),
-			$crawler->filter('label[for="allow_pm_markdown"]')->text()
-		);
-		$this->assertSame(1, $crawler->filter('#allow_pm_markdown')->count());
-		$this->assertTrue($form->has('config[allow_pm_markdown]'));
-		$this->assertSame('1', $form->get('config[allow_pm_markdown]')->getValue());
-	}
-
-	public function test_acp_signature_settings()
-	{
-		$this->admin_login();
-
-		$crawler = self::request('GET', sprintf(
-			'adm/index.php?i=acp_board&mode=signature&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertContains(
-			$this->lang('ALLOW_SIG_MARKDOWN'),
-			$crawler->filter('label[for="allow_sig_markdown"]')->text()
-		);
-		$this->assertSame(1, $crawler->filter('#allow_sig_markdown')->count());
-		$this->assertTrue($form->has('config[allow_sig_markdown]'));
-		$this->assertSame('1', $form->get('config[allow_sig_markdown]')->getValue());
-	}
-
-	public function test_ucp_posting_defaults()
-	{
-		$crawler = self::request('GET', sprintf(
-			'ucp.php?i=ucp_prefs&mode=post&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertTrue($form->has('markdown'));
-		$this->assertSame('1', $form->get('markdown')->getValue());
-	}
-
-	public function test_ucp_private_message()
-	{
-		$crawler = self::request('GET', sprintf(
-			'ucp.php?i=pm&mode=compose&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertSame(1, $crawler->filter('.markdown-status')->count());
-		$this->assertSame(
-			'/app.php/help/markdown',
-			$crawler->filter('.markdown-status > a')->attr('href')
-		);
-		$this->assertTrue($form->has('disable_markdown'));
-
-	}
-
-	public function test_ucp_signature()
-	{
-		$crawler = self::request('GET', sprintf(
-			'ucp.php?i=ucp_profile&mode=signature&sid=%s',
-			$this->sid
-		));
-
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-
-		$this->assertSame(1, $crawler->filter('.markdown-status')->count());
-		$this->assertSame(
-			'/app.php/help/markdown',
-			$crawler->filter('.markdown-status > a')->attr('href')
-		);
-
-		// It needs phpBB v3.2.6-RC1 or greater
-		// https://tracker.phpbb.com/browse/PHPBB3-15949
-		// https://github.com/phpbb/phpbb/pull/5519
-		$this->assertTrue($form->has('disable_markdown'));
 	}
 
 	public function test_post_reply()
@@ -262,28 +121,6 @@ EOT;
 			'#post-%d .content',
 			$private_message
 		));
-
-		$this->assertContains($expected, $result->html());
-	}
-
-	public function test_user_signature()
-	{
-		$crawler = self::request('GET', sprintf(
-			'ucp.php?i=ucp_profile&mode=signature&sid=%s',
-			$this->sid
-		));
-
-		$markdown = '**Markdown** ~~test~~';
-
-		$form = $crawler->selectButton($this->lang('PREVIEW'))->form([
-			'signature' => $markdown
-		]);
-
-		$crawler = self::submit($form);
-
-		$expected = '<p><strong>Markdown</strong> <del>test</del></p>';
-
-		$result = $crawler->filter('.postbody .signature');
 
 		$this->assertContains($expected, $result->html());
 	}

--- a/tests/functional/markdown_test.php
+++ b/tests/functional/markdown_test.php
@@ -46,6 +46,54 @@ class markdown_test extends phpbb_functional_test_case
 		$this->assertSame('1', $form->get('config[allow_markdown]')->getValue());
 	}
 
+	public function test_acp_post_settings()
+	{
+		$this->admin_login();
+
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=post&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertSame(1, $crawler->filter('#allow_post_markdown')->count());
+		$this->assertTrue($form->has('config[allow_post_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_post_markdown]')->getValue());
+	}
+
+	public function test_acp_private_message_settings()
+	{
+		$this->admin_login();
+
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=message&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertSame(1, $crawler->filter('#allow_pm_markdown')->count());
+		$this->assertTrue($form->has('config[allow_pm_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_pm_markdown]')->getValue());
+	}
+
+	public function test_acp_signature_settings()
+	{
+		$this->admin_login();
+
+		$crawler = self::request('GET', sprintf(
+			'adm/index.php?i=acp_board&mode=signature&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertSame(1, $crawler->filter('#allow_sig_markdown')->count());
+		$this->assertTrue($form->has('config[allow_sig_markdown]'));
+		$this->assertSame('1', $form->get('config[allow_sig_markdown]')->getValue());
+	}
+
 	public function test_ucp_posting_defaults()
 	{
 		$crawler = self::request('GET', sprintf(

--- a/tests/functional/markdown_test.php
+++ b/tests/functional/markdown_test.php
@@ -25,7 +25,10 @@ class markdown_test extends phpbb_functional_test_case
 	{
 		parent::setUp();
 
-		$this->add_lang_ext('alfredoramos/markdown', 'help/markdown');
+		$this->add_lang_ext('alfredoramos/markdown', [
+			'acp/info_acp_markdown',
+			'help/markdown'
+		]);
 
 		$this->login();
 	}
@@ -41,6 +44,10 @@ class markdown_test extends phpbb_functional_test_case
 
 		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
 
+		$this->assertContains(
+			$this->lang('ALLOW_MARKDOWN'),
+			$crawler->filter('label[for="allow_markdown"]')->text()
+		);
 		$this->assertSame(1, $crawler->filter('#allow_markdown')->count());
 		$this->assertTrue($form->has('config[allow_markdown]'));
 		$this->assertSame('1', $form->get('config[allow_markdown]')->getValue());
@@ -57,6 +64,10 @@ class markdown_test extends phpbb_functional_test_case
 
 		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
 
+		$this->assertContains(
+			$this->lang('ALLOW_POST_MARKDOWN'),
+			$crawler->filter('label[for="allow_post_markdown"]')->text()
+		);
 		$this->assertSame(1, $crawler->filter('#allow_post_markdown')->count());
 		$this->assertTrue($form->has('config[allow_post_markdown]'));
 		$this->assertSame('1', $form->get('config[allow_post_markdown]')->getValue());
@@ -73,6 +84,10 @@ class markdown_test extends phpbb_functional_test_case
 
 		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
 
+		$this->assertContains(
+			$this->lang('ALLOW_PM_MARKDOWN'),
+			$crawler->filter('label[for="allow_pm_markdown"]')->text()
+		);
 		$this->assertSame(1, $crawler->filter('#allow_pm_markdown')->count());
 		$this->assertTrue($form->has('config[allow_pm_markdown]'));
 		$this->assertSame('1', $form->get('config[allow_pm_markdown]')->getValue());
@@ -89,6 +104,10 @@ class markdown_test extends phpbb_functional_test_case
 
 		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
 
+		$this->assertContains(
+			$this->lang('ALLOW_SIG_MARKDOWN'),
+			$crawler->filter('label[for="allow_sig_markdown"]')->text()
+		);
 		$this->assertSame(1, $crawler->filter('#allow_sig_markdown')->count());
 		$this->assertTrue($form->has('config[allow_sig_markdown]'));
 		$this->assertSame('1', $form->get('config[allow_sig_markdown]')->getValue());

--- a/tests/functional/markdown_test.php
+++ b/tests/functional/markdown_test.php
@@ -247,6 +247,28 @@ EOT;
 		$this->assertContains($expected, $result->html());
 	}
 
+	public function test_user_signature()
+	{
+		$crawler = self::request('GET', sprintf(
+			'ucp.php?i=ucp_profile&mode=signature&sid=%s',
+			$this->sid
+		));
+
+		$markdown = '**Markdown** ~~test~~';
+
+		$form = $crawler->selectButton($this->lang('PREVIEW'))->form([
+			'signature' => $markdown
+		]);
+
+		$crawler = self::submit($form);
+
+		$expected = '<p><strong>Markdown</strong> <del>test</del></p>';
+
+		$result = $crawler->filter('.postbody .signature');
+
+		$this->assertContains($expected, $result->html());
+	}
+
 	public function test_markdown_help_page()
 	{
 		$crawler = self::request('GET', 'app.php/help/markdown');

--- a/tests/functional/markdown_test.php
+++ b/tests/functional/markdown_test.php
@@ -205,6 +205,48 @@ EOT;
 		$this->assertContains($expected, $result->html());
 	}
 
+	public function test_private_message()
+	{
+		$markdown = <<<EOT
+Code:
+
+```php
+echo 'message';
+```
+
+Inline `code`
+EOT;
+		$private_message = $this->create_private_message(
+			'Markdown private message test 1',
+			$markdown,
+			[2]
+		);
+
+		$crawler = self::request('GET', sprintf(
+			'ucp.php?i=pm&mode=view&p=%d&sid=%s',
+			$private_message,
+			$this->sid
+		));
+
+		$expected = <<<EOT
+<p>Code:</p>
+
+<div class="codebox">
+<p>Code: <a href="#" onclick="selectCode(this); return false;">Select all</a></p>
+<pre><code>echo 'message';</code></pre>
+</div>
+
+<p>Inline <code>code</code></p>
+EOT;
+
+		$result = $crawler->filter(sprintf(
+			'#post-%d .content',
+			$private_message
+		));
+
+		$this->assertContains($expected, $result->html());
+	}
+
 	public function test_markdown_help_page()
 	{
 		$crawler = self::request('GET', 'app.php/help/markdown');

--- a/tests/functional/ucp_markdown_test.php
+++ b/tests/functional/ucp_markdown_test.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Markdown extension for phpBB.
+ * @author Alfredo Ramos <alfredo.ramos@yandex.com>
+ * @copyright 2019 Alfredo Ramos
+ * @license GPL-2.0-only
+ */
+
+namespace alfredoramos\markdown\tests\functional;
+
+/**
+ * @group functional
+ */
+class ucp_markdown_test extends abstract_functional_test_case
+{
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->add_lang_ext('alfredoramos/markdown', 'ucp/markdown');
+	}
+
+	public function test_ucp_posting_defaults()
+	{
+		$crawler = self::request('GET', sprintf(
+			'ucp.php?i=ucp_prefs&mode=post&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertTrue($form->has('markdown'));
+		$this->assertSame('1', $form->get('markdown')->getValue());
+	}
+
+	public function test_ucp_private_message()
+	{
+		$crawler = self::request('GET', sprintf(
+			'ucp.php?i=pm&mode=compose&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertSame(1, $crawler->filter('.markdown-status')->count());
+		$this->assertSame(
+			'/app.php/help/markdown',
+			$crawler->filter('.markdown-status > a')->attr('href')
+		);
+		$this->assertTrue($form->has('disable_markdown'));
+
+	}
+
+	public function test_ucp_signature()
+	{
+		$crawler = self::request('GET', sprintf(
+			'ucp.php?i=ucp_profile&mode=signature&sid=%s',
+			$this->sid
+		));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+
+		$this->assertSame(1, $crawler->filter('.markdown-status')->count());
+		$this->assertSame(
+			'/app.php/help/markdown',
+			$crawler->filter('.markdown-status > a')->attr('href')
+		);
+
+		// It needs phpBB v3.2.6-RC1 or greater
+		// https://tracker.phpbb.com/browse/PHPBB3-15949
+		// https://github.com/phpbb/phpbb/pull/5519
+		$this->assertTrue($form->has('disable_markdown'));
+	}
+
+	public function test_ucp_signature_preview()
+	{
+		$crawler = self::request('GET', sprintf(
+			'ucp.php?i=ucp_profile&mode=signature&sid=%s',
+			$this->sid
+		));
+
+		$markdown = '**Markdown** ~~test~~';
+
+		$form = $crawler->selectButton($this->lang('PREVIEW'))->form([
+			'signature' => $markdown
+		]);
+
+		$crawler = self::submit($form);
+
+		$expected = '<p><strong>Markdown</strong> <del>test</del></p>';
+
+		$result = $crawler->filter('.postbody .signature');
+
+		$this->assertContains($expected, $result->html());
+	}
+}


### PR DESCRIPTION
- [x] Add more granular permissions
- [x] Update functional tests
- [x] Split functional test
- [x] Code cleanup

Now it does the following checks for Markdown permissions:

- If it is enabled globally by the administrator
- If it is enabled locally by the user
- If it is enabled for posts
    - If it allows the forum where the user is going to post
    - If it allows the group where the user belongs to
- If it is enabled for private messages
    - If it allows the group where the user belongs to
- If it is enabled for user signature
    - If it allows the group where the user belongs to

It means that now the administrator can disable, for example, the use of Markdown in private messages and leave it enabled for posts and user signature; or disable it for posts and leave it enabled for private messages and signature, and so on.