### PR TITLE
Keep posting option value

### DIFF
--- a/includes/helper.php
+++ b/includes/helper.php
@@ -65,8 +65,8 @@ class helper
 					$display_vars['vars'],
 					[
 						'allow_markdown' => array_merge(
-							['lang' => 'ALLOW_MARKDOWN'],
-							$options
+							$options,
+							['lang' => 'ALLOW_MARKDOWN']
 						)
 					],
 					['before' => 'allow_bbcode']
@@ -78,8 +78,8 @@ class helper
 					$display_vars['vars'],
 					[
 						'allow_post_markdown' => array_merge(
-							['lang' => 'ALLOW_POST_MARKDOWN'],
-							$options
+							$options,
+							['lang' => 'ALLOW_POST_MARKDOWN']
 						)
 					],
 					['before' => 'allow_bbcode']
@@ -91,8 +91,8 @@ class helper
 					$display_vars['vars'],
 					[
 						'allow_pm_markdown' => array_merge(
-							['lang' => 'ALLOW_PM_MARKDOWN'],
-							$options
+							$options,
+							['lang' => 'ALLOW_PM_MARKDOWN']
 						)
 					],
 					['before' => 'auth_bbcode_pm']
@@ -104,8 +104,8 @@ class helper
 					$display_vars['vars'],
 					[
 						'allow_sig_markdown' => array_merge(
-							['lang' => 'ALLOW_SIG_MARKDOWN'],
-							$options
+							$options,
+							['lang' => 'ALLOW_SIG_MARKDOWN']
 						)
 					],
 					['before' => 'allow_sig_bbcode']

--- a/migrations/v13x/m00_post_configuration.php
+++ b/migrations/v13x/m00_post_configuration.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Markdown extension for phpBB.
+ * @author Alfredo Ramos <alfredo.ramos@yandex.com>
+ * @copyright 2019 Alfredo Ramos
+ * @license GPL-2.0-only
+ */
+
+namespace alfredoramos\markdown\migrations\v13x;
+
+use phpbb\db\migration\migration;
+
+class m00_post_configuration extends migration
+{
+	/**
+	 * Check configuration data exist.
+	 *
+	 * @return bool
+	 */
+	public function effectively_installed()
+	{
+		return $this->db_tools->sql_column_exists(POSTS_TABLE, 'enable_markdown');
+	}
+
+	/**
+	 * Add post configuration.
+	 *
+	 * @return array
+	 */
+	public function update_schema()
+	{
+		return [
+			'add_columns' => [
+				POSTS_TABLE => [
+					'enable_markdown' => ['BOOL', 1]
+				]
+			]
+		];
+	}
+
+	/**
+	 * Revert post configuration.
+	 *
+	 * @return array
+	 */
+	public function revert_schema()
+	{
+		return [
+			'drop_columns' => [
+				POSTS_TABLE => [
+					'enable_markdown'
+				]
+			]
+		];
+	}
+}

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -85,6 +85,8 @@ class listener_test extends phpbb_test_case
 				'core.ucp_prefs_post_data',
 				'core.ucp_prefs_post_update_data',
 				'core.posting_modify_message_text',
+				'core.posting_modify_submit_post_before',
+				'core.submit_post_modify_sql_data',
 				'core.posting_modify_template_vars',
 				'core.ucp_pm_compose_modify_parse_before',
 				'core.message_parser_check_message'


### PR DESCRIPTION
With his change the posting option will keep its value in posts

Keep the value of the Markdown posting option in:

- [x] Posts
- [ ] ~Private message~
- [ ] ~Signature~

It doesn't have PHP events to keep value on private messages or signatures.

Fixes #35 