### PR TITLE
Remove s9e/text-formatter dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
     - IMAGE_ICC="1"                     # ICC profile sniffer switch
     - EPV="1"                           # Extension pre-validator switch
     - PHPBB_BRANCH="3.3.x"              # phpBB branch
-    - EXTDEPS="1"                       # Extension dependencies switch
+    - EXTDEPS="0"                       # Extension dependencies switch
 
 branches:
   only:

--- a/Rakefile
+++ b/Rakefile
@@ -152,9 +152,9 @@ class Helper
   def minified_ext(file_path)
     ext = File.extname(file_path)
 
-    return file_path if file_path.end_with?('.min' + ext)
+    return file_path if file_path.end_with?(format('.min%<ext>s', ext: ext))
 
-    file_path.gsub(ext, '.min' + ext)
+    file_path.gsub(ext, format('.min%<ext>s', ext: ext))
   end
 end
 

--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 	Only set this to "true" if you have dependencies in the composer.json,
 	otherwise use "false".
 	-->
-	<property name="has-dependencies" value="true" />
+	<property name="has-dependencies" value="false" />
 
 	<!--
 	Remove some unnecessary files/directories

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
 	],
 	"require": {
 		"php": "^7.1.3",
-		"composer/installers": "^1.6.0",
-		"s9e/text-formatter": "^2.7.0"
+		"composer/installers": "^1.6.0"
 	},
 	"require-dev": {
 		"phing/phing": "^2.16.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"extra": {
 		"display-name": "Markdown",
 		"soft-require": {
-			"phpbb/phpbb": "~3.3.0"
+			"phpbb/phpbb": "~3.3.2"
 		},
 		"version-check": {
 			"host": "alfredoramos.mx",

--- a/ext.php
+++ b/ext.php
@@ -20,6 +20,6 @@ class ext extends base
 	 */
 	public function is_enableable()
 	{
-		return phpbb_version_compare(PHPBB_VERSION, '3.3.0', '>=');
+		return phpbb_version_compare(PHPBB_VERSION, '3.3.2', '>=');
 	}
 }


### PR DESCRIPTION
It can only be merged when phpBB releases a stable version that includes a `s9e/text-formatter` version equal or higher than the following:

- [x] 2.6.0
	- Required by: TaskLists plugin (#43)
	- Included in: phpBB 3.3.1
- [x] 2.7.0
	- Required by: Litedown plugin (headers with slugs feature) (#53)
	- Included in: phpBB 3.3.2